### PR TITLE
Delete Turkish translation

### DIFF
--- a/locale/tr.yml
+++ b/locale/tr.yml
@@ -1,4 +1,0 @@
-dem13n:
-  forum:
-    topic_starter: Konu Sahibi
-    blog_article_author: Yazar


### PR DESCRIPTION
This extension is translated in Turkish language pack: https://github.com/flarum-lang/turkish/blob/main/locale/dem13n-topic-starter-label.yml

If you don't know Turkish, it is probably better to delegate translating to language pack than relying on contributions to extension repository.